### PR TITLE
Added relative path support for opening files in grunt project folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "open": "~0.0.4"
+    "open": "~0.0.4",
+    "path": "~0.4.9"
   },
   "devDependencies": {
     "grunt": "~0.4.0",

--- a/tasks/open.js
+++ b/tasks/open.js
@@ -9,11 +9,16 @@
 'use strict';
 
 var open = require('open');
+var path = require('path');
 
 module.exports = function(grunt) {
   grunt.registerMultiTask('open', 'Open urls and files from a grunt task', function() {
     var dest = this.data.url || this.data.file || this.data.path;
     var application = this.data.app || this.data.application;
+    var isRelativePath = this.data.isRelativePath || false;
+
+    // add relative path reference
+    if(isRelativePath) { dest = path.resolve(dest); }
 
     function callback(error){
     if (error !== null)


### PR DESCRIPTION
Added node "path" dependency in preparation for relative path support.

Added isRelativePath:boolean option allowing grunt-open to launch files relative to Gruntfile.js. 

Use case:
User creates a build of their project and wishes to launch the file in Internet Explorer (ugh I know) using the file:// protocol.  Setting the relative path to true will cause grunt-open to get the full path to the file allowing it to open properly. 
