### PR TITLE
Allow dynamic destinations

### DIFF
--- a/tasks/open.js
+++ b/tasks/open.js
@@ -20,7 +20,7 @@ module.exports = function(grunt) {
       grunt.fail.warn(error);
     }
 
-    open(dest, application, callback);
+    open(typeof dest === 'function' ? dest.apply(grunt, arguments) : dest, application, callback);
 
     // give the spawn some time before its parent (us) dies
     // https://github.com/onehealth/grunt-open/issues/6


### PR DESCRIPTION
Lets you specify a destination as a function, e.g.

``` javascript
grunt.initConfig({
  open: {
    url: function (env) {
      return 'http://localhost:'+envs[env].port;
    }
  }
});

var envs = {local: {port: 8080}, test: {port: 8081}};

grunt.task.run('open:local');
```
