### PR TITLE
Allow opening multiple destinations.

### DIFF
--- a/tasks/open.js
+++ b/tasks/open.js
@@ -14,6 +14,11 @@ module.exports = function(grunt) {
   grunt.registerMultiTask('open', 'Open urls and files from a grunt task', function() {
     var dest = this.data.url || this.data.file || this.data.path;
     dest = typeof dest === 'function' ? dest() : dest;
+
+    if (typeof dest === 'string') {
+      dest = [dest]
+    }
+
     var application = this.data.app || this.data.application;
     var options = this.options();
 
@@ -28,11 +33,15 @@ module.exports = function(grunt) {
     var openOn = options.openOn;
     if (openOn) {
       grunt.event.on(openOn, function () {
-        open(dest, application, callback);
+        dest.forEach(function(dest){
+          open(dest, application, callback);
+        })
       });
     } else {
       setTimeout(function(){
-        open(dest, application, callback);
+        dest.forEach(function(dest){
+          open(dest, application, callback);
+        })
       }, options.delay);
     }
 

--- a/tasks/open.js
+++ b/tasks/open.js
@@ -16,7 +16,7 @@ module.exports = function(grunt) {
     dest = typeof dest === 'function' ? dest() : dest;
 
     if (typeof dest === 'string') {
-      dest = [dest]
+      dest = [dest];
     }
 
     var application = this.data.app || this.data.application;
@@ -35,13 +35,13 @@ module.exports = function(grunt) {
       grunt.event.on(openOn, function () {
         dest.forEach(function(dest){
           open(dest, application, callback);
-        })
+        });
       });
     } else {
       setTimeout(function(){
         dest.forEach(function(dest){
           open(dest, application, callback);
-        })
+        });
       }, options.delay);
     }
 


### PR DESCRIPTION
My changes converts string `dest` to a single item array to be backward compatible. If you pass an array of destination in `dest` config in Gruntfile, it will loop on that array and open those destinations one by one.

Here is the [screencast](http://monosnap.com/file/VNlVZyp09Oil3pxfDBi8te7mu67K6D) to screencast.