### PR TITLE
Open only once

### DIFF
--- a/tasks/open.js
+++ b/tasks/open.js
@@ -27,7 +27,7 @@ module.exports = function(grunt) {
     // allows to wait for server start up before opening
     var openOn = options.openOn;
     if (openOn) {
-      grunt.event.on(openOn, function () {
+      grunt.event.once(openOn, function () {
         open(dest, application, callback);
       });
     } else {


### PR DESCRIPTION
If the event is fired multiple times, do not continue to open the page. Requires the open task to be run again in order to open again.

This may be a breaking change for anyone using openOn with the expectation that it continues firing every time the event occurs. Please let me know if you would prefer to retain the behavior of `openOn` but add `openOnce` as well. I think that is a bit confusing but it would avoid breaking anything that was depending on the event listening and firing throughout the life of the grunt task. My suspicion is that this is more often an undiscovered side-effect than an expected behavior.